### PR TITLE
Fixed a typo in a unit test.

### DIFF
--- a/test/range.test.js
+++ b/test/range.test.js
@@ -8,6 +8,7 @@ describe('range.js module', function() {
   });
 
   it('should calculate a fixed range', function() {
-    expect(64).toEqual(64, range.getRange());
+    expect(64).toEqual(range.getRange());
+    expect(65).not.toEqual(range.getRange());
   });
 });


### PR DESCRIPTION
Fixed a typo in a unit test.
Also added another test to ensure that the range function always returns the same value, as expected.