### PR TITLE
There's no need to instantiate an order object

### DIFF
--- a/app/line.js
+++ b/app/line.js
@@ -47,7 +47,7 @@ Line.prototype.generatedPoints = function(array) {
 
 	var i;
 	var range = new Range().getRange();
-	var start = range * (new Order().createOrder(this.index) % 11);
+	var start = range * (Order.createOrder(this.index) % 11);
 	var noise = this.noise.initializeNoise(perlin, range, start, array);
 
 	var invertedPerlin = noise.slice(0);

--- a/app/order.js
+++ b/app/order.js
@@ -6,7 +6,7 @@ var Order = function() {
 //TODO refactor magic numbers
 //TODO document
 //TODO add tests
-Order.prototype.createOrder = function(index) {
+Order.createOrder = function(index) {
   if (typeof index === 'undefined' || index === null) return undefined;
 
 	return index < 11 ? 10 - index : index;

--- a/test/order.test.js
+++ b/test/order.test.js
@@ -1,24 +1,19 @@
 var Order = require('../app/order.js');
 
-var order;
-
 describe('Order.js module', function() {
-  beforeAll(function() {
-    order = new Order();
-  });
 
   it('should create an order based on an index', function() {
-    expect(order.createOrder(0)).toEqual(10);
-    expect(order.createOrder(1)).toEqual(9);
-    expect(order.createOrder(2)).toEqual(8);
-    expect(order.createOrder(10)).toEqual(0);
-    expect(order.createOrder(11)).toEqual(11);
-    expect(order.createOrder(12)).toEqual(12);
-    expect(order.createOrder(-1)).toEqual(11);
+    expect(Order.createOrder(0)).toEqual(10);
+    expect(Order.createOrder(1)).toEqual(9);
+    expect(Order.createOrder(2)).toEqual(8);
+    expect(Order.createOrder(10)).toEqual(0);
+    expect(Order.createOrder(11)).toEqual(11);
+    expect(Order.createOrder(12)).toEqual(12);
+    expect(Order.createOrder(-1)).toEqual(11);
   });
   
   it('should return undefined when receiving undefined or null', function() {
-    expect(order.createOrder()).toEqual(undefined);
-    expect(order.createOrder(null)).toEqual(undefined);
+    expect(Order.createOrder()).toEqual(undefined);
+    expect(Order.createOrder(null)).toEqual(undefined);
   });
 });


### PR DESCRIPTION
Turned the createOrder method 'static'.